### PR TITLE
Fixed food consumption bonus calculation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@influenceth/sdk",
-  "version": "2.1.0-beta.75",
+  "version": "2.1.0-beta.76",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@influenceth/sdk",
-      "version": "2.1.0-beta.75",
+      "version": "2.1.0-beta.76",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@influenceth/astro": "^0.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influenceth/sdk",
-  "version": "2.1.0-beta.75",
+  "version": "2.1.0-beta.76",
   "description": "Influence SDK",
   "type": "module",
   "module": "./build/index.js",

--- a/src/lib/crewmate.js
+++ b/src/lib/crewmate.js
@@ -366,7 +366,8 @@ const ABILITY_TYPES = {
       [DEPARTMENT_IDS.FOOD_PREPARATION]: 0.025,
       [DEPARTMENT_IDS.MANAGEMENT]: 0.005
     },
-    traits: { [TRAIT_IDS.DIETITIAN]: 0.05 }
+    traits: { [TRAIT_IDS.DIETITIAN]: 0.05 },
+    notFurtherModified: true
   },
   [ABILITY_IDS.FOOD_RATIONING_PENALTY]: {
     name: 'Food Rationing Penalty',

--- a/test/lib/asteroid.spec.js
+++ b/test/lib/asteroid.spec.js
@@ -41,7 +41,7 @@ describe('Asteroid library', function () {
     expect(LasteroidArea).to.equal(13);
   });
 
-  it.only('should get unpacked abundances', function () {
+  it('should get unpacked abundances', function () {
     let abundances = {};
     abundances = asteroid.getAbundances(0n);
     expect(Object.keys(abundances).length).to.equal(22);


### PR DESCRIPTION
Fixes food consumption time bonus by ensuring it's not further modified (should only be based on crewmates)