### PR TITLE
Fixes for regressions caused by newly added Processes

### DIFF
--- a/src/lib/process.js
+++ b/src/lib/process.js
@@ -3869,7 +3869,8 @@ const TYPES = {
       [Product.IDS.POWER_MODULE]: 2,
       [Product.IDS.THERMAL_MODULE]: 1,
       [Product.IDS.PROPULSION_MODULE]: 1
-    }
+    },
+    outputs: {}
   },
   [IDS.LIGHT_TRANSPORT_INTEGRATION]: {
     i: IDS.LIGHT_TRANSPORT_INTEGRATION,
@@ -3887,7 +3888,8 @@ const TYPES = {
       [Product.IDS.POWER_MODULE]: 4,
       [Product.IDS.THERMAL_MODULE]: 1,
       [Product.IDS.PROPULSION_MODULE]: 2
-    }
+    },
+    outputs: {}
   },
   [IDS.HEAVY_TRANSPORT_INTEGRATION]: {
     i: IDS.HEAVY_TRANSPORT_INTEGRATION,
@@ -3904,7 +3906,8 @@ const TYPES = {
       [Product.IDS.POWER_MODULE]: 6,
       [Product.IDS.THERMAL_MODULE]: 3,
       [Product.IDS.PROPULSION_MODULE]: 9
-    }
+    },
+    outputs: {}
   },
   [IDS.WAREHOUSE_CONSTRUCTION]: {
     i: IDS.WAREHOUSE_CONSTRUCTION,
@@ -3916,7 +3919,8 @@ const TYPES = {
       [Product.IDS.CEMENT]: 400000,
       [Product.IDS.STEEL_BEAM]: 350000,
       [Product.IDS.STEEL_SHEET]: 200000
-    }
+    },
+    outputs: {}
   },
   [IDS.EXTRACTOR_CONSTRUCTION]: {
     i: IDS.EXTRACTOR_CONSTRUCTION,
@@ -3930,7 +3934,8 @@ const TYPES = {
       [Product.IDS.POLYACRYLONITRILE_FABRIC]: 3000,
       [Product.IDS.FLUIDS_AUTOMATION_MODULE]: 1,
       [Product.IDS.POWER_MODULE]: 6
-    }
+    },
+    outputs: {}
   },
   [IDS.REFINERY_CONSTRUCTION]: {
     i: IDS.REFINERY_CONSTRUCTION,
@@ -3948,7 +3953,8 @@ const TYPES = {
       [Product.IDS.AVIONICS_MODULE]: 2,
       [Product.IDS.POWER_MODULE]: 16,
       [Product.IDS.THERMAL_MODULE]: 4
-    }
+    },
+    outputs: {}
   },
   [IDS.BIOREACTOR_CONSTRUCTION]: {
     i: IDS.BIOREACTOR_CONSTRUCTION,
@@ -3969,7 +3975,8 @@ const TYPES = {
       [Product.IDS.SOLIDS_AUTOMATION_MODULE]: 12,
       [Product.IDS.AVIONICS_MODULE]: 3,
       [Product.IDS.POWER_MODULE]: 8
-    }
+    },
+    outputs: {}
   },
   [IDS.FACTORY_CONSTRUCTION]: {
     i: IDS.FACTORY_CONSTRUCTION,
@@ -3986,7 +3993,8 @@ const TYPES = {
       [Product.IDS.AVIONICS_MODULE]: 8,
       [Product.IDS.POWER_MODULE]: 20,
       [Product.IDS.THERMAL_MODULE]: 6
-    }
+    },
+    outputs: {}
   },
   [IDS.SHIPYARD_CONSTRUCTION]: {
     i: IDS.SHIPYARD_CONSTRUCTION,
@@ -4003,7 +4011,8 @@ const TYPES = {
       [Product.IDS.AVIONICS_MODULE]: 10,
       [Product.IDS.POWER_MODULE]: 24,
       [Product.IDS.THERMAL_MODULE]: 6
-    }
+    },
+    outputs: {}
   },
   [IDS.SPACEPORT_CONSTRUCTION]: {
     i: IDS.SPACEPORT_CONSTRUCTION,
@@ -4021,7 +4030,8 @@ const TYPES = {
       [Product.IDS.AVIONICS_MODULE]: 16,
       [Product.IDS.POWER_MODULE]: 40,
       [Product.IDS.THERMAL_MODULE]: 40
-    }
+    },
+    outputs: {}
   },
   [IDS.MARKETPLACE_CONSTRUCTION]: {
     i: IDS.MARKETPLACE_CONSTRUCTION,
@@ -4039,7 +4049,8 @@ const TYPES = {
       [Product.IDS.AVIONICS_MODULE]: 12,
       [Product.IDS.POWER_MODULE]: 20,
       [Product.IDS.THERMAL_MODULE]: 20
-    }
+    },
+    outputs: {}
   },
   [IDS.HABITAT_CONSTRUCTION]: {
     i: IDS.HABITAT_CONSTRUCTION,
@@ -4059,7 +4070,8 @@ const TYPES = {
       [Product.IDS.AVIONICS_MODULE]: 20,
       [Product.IDS.POWER_MODULE]: 30,
       [Product.IDS.THERMAL_MODULE]: 20
-    }
+    },
+    outputs: {}
   }
 };
 

--- a/src/utils/ProductionJSON.js
+++ b/src/utils/ProductionJSON.js
@@ -150,8 +150,6 @@ class ProductionJSON {
     /**
      * Add "processes" to the JSON, initially without:
      * - raw materials (mining)
-     * - ships (integration)
-     * - buildings (construction)
      */
     Object.values(Process.TYPES).forEach(processData => {
       this.productionChainsJSON.processes.push({
@@ -204,48 +202,38 @@ class ProductionJSON {
     });
 
     /**
-     * Add ships (integration) to "processes" in the JSON
-     * - e.g. ship "Shuttle" => process "Shuttle Integration"
+     * Add ships-as-products to ship integration process outputs.
      */
     Object.entries(this.shipIdToProductId).forEach(([shipId, productId]) => {
       const setupTime = Ship.CONSTRUCTION_TYPES[shipId].setupTime;
       const constructionTime = Ship.CONSTRUCTION_TYPES[shipId].constructionTime;
-      const inputs = Ship.CONSTRUCTION_TYPES[shipId].requirements;
-      this.productionChainsJSON.processes.push({
-        bAdalianHoursPerAction: this.getHoursFromSeconds(setupTime),
-        buildingId: String(Building.IDS.SHIPYARD),
-        id: String(++maxProcessId),
-        inputs: this.getFormattedInputsOrOutputs(inputs),
-        mAdalianHoursPerSR: this.getHoursFromSeconds(constructionTime),
-        name: Ship.TYPES[shipId].name + ' Integration', // e.g. "Shuttle Integration"
-        outputs: [{
-          productId: String(productId),
-          unitsPerSR: '1'
-        }]
-      });
+      const process = this.productionChainsJSON.processes.find(p => p.name === Ship.TYPES[shipId].name + ' Integration');
+      process.bAdalianHoursPerAction = this.getHoursFromSeconds(setupTime);
+      process.buildingId = String(Building.IDS.SHIPYARD);
+      process.id = String(++maxProcessId);
+      process.mAdalianHoursPerSR = this.getHoursFromSeconds(constructionTime);
+      process.outputs = [{
+        productId: String(productId),
+        unitsPerSR: '1'
+      }];
     });
 
     /**
-     * Add buildings (construction) to "processes" in the JSON
-     * - e.g. building "Warehouse" => process "Warehouse Construction"
+     * Add buildings-as-products to building construction process outputs.
      */
     Object.entries(this.buildingIdToProductId).forEach(([buildingId, productId]) => {
-      // NOTE: "setupTime" not yet defined for buildings construction, as of v2.1.0-beta.52
+      // NOTE: "setupTime" not yet defined for buildings construction, as of v2.1.0-beta.99
       const setupTime = Building.CONSTRUCTION_TYPES[buildingId].setupTime;
       const constructionTime = Building.CONSTRUCTION_TYPES[buildingId].constructionTime;
-      const inputs = Building.CONSTRUCTION_TYPES[buildingId].requirements;
-      this.productionChainsJSON.processes.push({
-        bAdalianHoursPerAction: setupTime ? this.getHoursFromSeconds(setupTime) : 'N/A',
-        buildingId: String(Building.IDS.EMPTY_LOT),
-        id: String(++maxProcessId),
-        inputs: this.getFormattedInputsOrOutputs(inputs),
-        mAdalianHoursPerSR: this.getHoursFromSeconds(constructionTime),
-        name: Building.TYPES[buildingId].name + ' Construction', // e.g. "Warehouse Construction"
-        outputs: [{
-          productId: String(productId),
-          unitsPerSR: '1'
-        }]
-      });
+      const process = this.productionChainsJSON.processes.find(p => p.name === Building.TYPES[buildingId].name + ' Construction');
+      process.bAdalianHoursPerAction = setupTime ? this.getHoursFromSeconds(setupTime) : 'N/A';
+      process.buildingId = String(Building.IDS.EMPTY_LOT);
+      process.id = String(++maxProcessId);
+      process.mAdalianHoursPerSR = this.getHoursFromSeconds(constructionTime)
+      process.outputs = [{
+        productId: String(productId),
+        unitsPerSR: '1'
+      }];
     });
 
     /**


### PR DESCRIPTION
Added new process outputs as empty objects that are safe to iterate through, instead of causing undefined error. Previously existing objects can be though to have established a contract of structure and leaving the outputs undefined kinda breaks that contract, causing downstream usage to break unexpectedly.

Adjusted the JSON file export process to no longer try to add Integration and Construction processes since they now exist. Now only augmenting existing data like in previous functionality.