### PR TITLE
DevOps: GitHub Actions

### DIFF
--- a/.github/workflows/beta-version.yml
+++ b/.github/workflows/beta-version.yml
@@ -1,0 +1,45 @@
+name: Build beta version
+
+on:
+  push:
+    branches:
+      -master
+
+jobs:
+  create-beta-version:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Increment Beta Version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          BASE_VERSION=$(echo $VERSION | sed 's/-beta\.[0-9]*//')
+          BETA_NUMBER=$(echo $VERSION | sed -n 's/.*-beta\.\([0-9]*\)/\1/p')
+          NEW_BETA_NUMBER=$((BETA_NUMBER + 1))
+          NEW_VERSION="$BASE_VERSION-beta.$NEW_BETA_NUMBER"
+          npm version $NEW_VERSION --no-git-tag-version
+          echo "New version: $NEW_VERSION"
+
+      - name: Commit and push changes
+        run: |
+          git config --global user.name 'github-actions'
+          git config --global user.email 'github-actions@github.com'
+          git add package.json
+          git commit -m "Create beta version $NEW_VERSION"
+          git push

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,40 @@
+name: Build and Publish SDK
+
+on:
+  push:
+    branches:
+      - main
+
+# on:
+#   release:
+#     types:
+#       - published
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build SDK
+        run: npm run build
+
+      - name: Publish SDK to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+        run: npm run publish-sdk

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,14 +1,9 @@
 name: Build and Publish SDK
 
 on:
-  push:
-    branches:
-      - main
-
-# on:
-#   release:
-#     types:
-#       - published
+  release:
+    types:
+      - published
 
 jobs:
   build-and-publish:

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "export-production-chains": "node ./src/scripts/exportProductionChains.js",
     "lint": "eslint ./src",
     "prepublishOnly": "npm run build",
-    "test": "NODE_ENV=test ./node_modules/.bin/mocha --recursive"
+    "test": "NODE_ENV=test ./node_modules/.bin/mocha --recursive",
+    "publish-sdk": "npm run build && npm publish --access public"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Issue

Solves #91 

# Description
We should include an npm job that builds and publishes the SDK with a specific version, as well as a Github Action that automatically builds a beta version (i.e. 2.1.0-beta.123) based on the current version.

# Solution
- Added two new GitHub Actions.
- One will generate a new beta version on push to master branch. This version will be based on the current one (defined on the `package.json` file with an increment on the last number).
- The other action will be triggered whenever there's a new release published on github. This will publish the SDK.


# Important
1. In order for the beta version creation to work, this workflow permission must be updated under the repository settings:

<img width="762" alt="Screenshot 2024-06-24 at 19 42 41" src="https://github.com/influenceth/sdk/assets/87027508/71280b79-7f4f-4405-bc12-30f72ca5e954">

2. For the publish to npm to work, the `NPM_AUTH_TOKEN` must be added to the secrets.