### PR TITLE
Fix: GH Actions

### DIFF
--- a/.github/workflows/beta-version.yml
+++ b/.github/workflows/beta-version.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/beta-version.yml
+++ b/.github/workflows/beta-version.yml
@@ -16,6 +16,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: master
+          token: ${{ secrets.REPO_TOKEN }}
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/beta-version.yml
+++ b/.github/workflows/beta-version.yml
@@ -1,13 +1,14 @@
 name: Build beta version
 
 on:
-  push:
-    branches:
-      - master
+  pull_request:
+    types:
+      - closed
 
 jobs:
   create-beta-version:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'master'
 
     strategy:
       matrix:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Description
The master branch of the repo is protected, this is preventing the GitHub action to commit directly to this branch when creating a new beta version. To avoid this the workflow was updated to use a PAT that gives it the necessary access.
Also:
a. The workflows were just left with node version 20 to avoid duplicated runs.
b. The trigger action was updated to "on merged PR to master" instead of "on push to master" to avoid a cycle.

## Issue
This is related to #91 

## Important Steps
Please add a new PAT to the repo secrets. For this follow the steps below:
1. Go to developer settings.
2. Go to Personal Access Tokens.
3. Add a descriptive name, expiration and select the scopes, or permissions, you’d like to grant this token. For this scenario just choose `public_repo`.
4. Generate the token and copy it.
5. Now go to the repo settings.
6. Under secrets add a new secret with the name `REPO_TOKEN` and paste the personal access token generated before.