### PR TITLE
feat: add Component wrapper class for on-chain snake_case data

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,161 @@ for (const [spectralId, spectralData] of Object.entries(spectralTypesData)) {
 }
 ```
 
+### Examples
+
+#### Working with Entities
+
+Entities in Influence are identified by a label (type) and numeric ID, packed into a single UUID.
+
+```js
+import { Entity } from '@influenceth/sdk';
+
+// Pack an entity into a hex UUID
+const crewUuid = Entity.packEntity({ label: Entity.IDS.CREW, id: 4938 });
+console.log(crewUuid); // '0x134a0001'
+
+// Unpack a UUID back into label and id
+const entity = Entity.unpackEntity(crewUuid);
+console.log(entity); // { id: 4938, label: 1 }
+
+// Format from various inputs (object, uuid, or bigint)
+const formatted = Entity.formatEntity({ label: Entity.IDS.ASTEROID, id: 1 });
+console.log(formatted); // { id: 1, label: 3, uuid: '0x10003' }
+
+// Compare two entities
+const isSame = Entity.areEqual(
+  { label: Entity.IDS.SHIP, id: 42 },
+  { label: Entity.IDS.SHIP, id: 42 }
+);
+console.log(isSame); // true
+```
+
+#### Querying Products and Resources
+
+```js
+import { Product } from '@influenceth/sdk';
+
+// Get all raw materials
+const rawMaterials = Product.getListByClassification(Product.CLASSIFICATIONS.RAW_MATERIAL);
+console.log(`${rawMaterials.length} raw materials available`);
+
+// Look up a specific product by ID
+const water = Product.TYPES[Product.IDS.WATER];
+console.log(water.name);           // 'Water'
+console.log(water.classification); // 1 (RAW_MATERIAL)
+console.log(water.category);       // 1 (VOLATILE)
+
+// Get all products in a category
+const metals = Object.entries(Product.TYPES)
+  .filter(([, p]) => p.category === Product.CATEGORIES.METAL);
+console.log(`${metals.length} metal products`);
+```
+
+#### Asteroid Spectral Types
+
+```js
+import { Asteroid, Product } from '@influenceth/sdk';
+
+// List all spectral types and their available resources
+for (const [id, spectral] of Object.entries(Asteroid.SPECTRAL_TYPES)) {
+  const resourceNames = spectral.resources.map(rId => Product.TYPES[rId].name);
+  console.log(`${spectral.name}-type (density: ${spectral.density}): ${resourceNames.join(', ')}`);
+}
+
+// Get asteroid size and rarity classifications
+console.log(Asteroid.SIZES);    // ['Small', 'Medium', 'Large', 'Huge']
+console.log(Asteroid.RARITIES); // ['Common', 'Uncommon', 'Rare', 'Superior', 'Exceptional', 'Incomparable']
+```
+
+#### Buildings and Processes
+
+```js
+import { Building, Process } from '@influenceth/sdk';
+
+// List building types
+for (const [id, building] of Object.entries(Building.TYPES)) {
+  if (building.name) {
+    console.log(`${building.name} (category: ${building.category})`);
+  }
+}
+
+// Look up a specific process
+const electrolysis = Process.TYPES[Process.IDS.WATER_ELECTROLYSIS];
+console.log(electrolysis.name); // 'Water Electrolysis'
+```
+
+#### Ships and Propellant
+
+```js
+import { Ship } from '@influenceth/sdk';
+
+// Get ship type details
+const lightTransport = Ship.getType(Ship.IDS.LIGHT_TRANSPORT);
+console.log(lightTransport.name);
+
+// Calculate propellant needed for a journey
+const propellantKg = Ship.getPropellantRequirement(
+  Ship.IDS.LIGHT_TRANSPORT,
+  50000,   // wet mass in kg
+  500      // delta-v in m/s
+);
+console.log(`Propellant required: ${propellantKg} kg`);
+```
+
+#### Time Conversions
+
+The in-game clock runs at 24x real time by default.
+
+```js
+import { Time } from '@influenceth/sdk';
+
+// Convert real-world duration to in-game duration
+const realSeconds = 3600; // 1 real hour
+const gameSeconds = Time.toGameDuration(realSeconds);
+console.log(`1 real hour = ${gameSeconds} in-game seconds (${gameSeconds / 3600} in-game hours)`);
+
+// Convert in-game duration to real-world duration
+const gameDuration = 86400; // 1 in-game day
+const realDuration = Time.toRealDuration(gameDuration);
+console.log(`1 in-game day = ${realDuration} real seconds (${realDuration / 60} real minutes)`);
+```
+
+#### Using Contract ABIs
+
+```js
+import { starknetContracts, ethereumContracts, starknetAddresses, Entity } from '@influenceth/sdk';
+
+// Access Starknet contract ABIs for use with starknet.js
+console.log('Available Starknet contracts:', Object.keys(starknetContracts));
+
+// Read a component from the Dispatcher contract
+// Example: reading a Crew component using starknet.js
+// const provider = new Provider({ nodeUrl: 'YOUR_RPC_URL' });
+// const dispatcher = new Contract(starknetContracts.Dispatcher, starknetAddresses.Dispatcher, provider);
+// const crewData = await dispatcher.call('run_system', {
+//   name: 'ReadComponent',
+//   calldata: ['Crew', 1, Entity.packEntity({ label: Entity.IDS.CREW, id: 4938 })]
+// });
+```
+
+#### Crew Ability Bonuses
+
+```js
+import { Crew, Crewmate } from '@influenceth/sdk';
+
+// Calculate ability bonus for a crew
+const crewmates = [
+  { classId: 1, traitIds: [1, 2], titleId: 0 },
+  { classId: 2, traitIds: [3], titleId: 1 }
+];
+
+const station = { stationType: 1, population: 100 };
+const timeSinceFed = 0; // well-fed crew
+
+const bonus = Crew.getAbilityBonus(1, crewmates, station, timeSinceFed);
+console.log(`Total bonus multiplier: ${bonus.totalBonus}`);
+```
+
 ## API
 1. The API is whitelist only, please request access to the #community-devs channel in the Influence Discord: https://discord.gg/influenceth to receive an API key.
 2. If possible, prefer using the exports here: https://www.dropbox.com/sh/5g3ww8wi9n0p4s6/AADcR0lgL8iKTQrpiWUC37Oxa?dl=0 rather than adding additional load to the API.

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ import Product from './lib/product.js';
 import RandomEvent from './lib/randomEvent.js';
 import Ship from './lib/ship.js';
 import Station from './lib/station.js';
+import Component from './lib/Component.js';
 import System from './lib/system.js';
 
 import AdalianOrbit from './utils/AdalianOrbit.js';
@@ -67,6 +68,7 @@ export {
   Assets,
   Asteroid,
   Building,
+  Component,
   Crew,
   Crewmate,
   Delivery,

--- a/src/lib/Component.js
+++ b/src/lib/Component.js
@@ -1,0 +1,105 @@
+import starknetComponents from '../contracts/starknet_components.json' assert { type: 'json' };
+
+/**
+ * Converts a snake_case string to camelCase
+ * @param {string} str - snake_case string
+ * @returns {string} camelCase string
+ */
+const snakeToCamel = (str) => str.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase());
+
+/**
+ * Creates a camelCase-mapped component object from raw on-chain snake_case data.
+ * Property names from StarkNet contracts are in snake_case; the SDK entity
+ * libraries (e.g. Asteroid.Component.getBonuses) expect camelCase.
+ *
+ * @param {string} componentName - The component name as it appears in starknet_components.json
+ *   (e.g. 'Celestial', 'Crew', 'Building'). The full ABI key
+ *   (e.g. 'influence::components::celestial::Celestial') is also accepted.
+ * @param {object} rawData - Raw component data from chain (snake_case keys)
+ * @returns {object} Component instance with camelCase properties
+ *
+ * @example
+ * // Raw data from ReadComponent system call
+ * const rawCelestial = {
+ *   celestial_type: 3n,
+ *   mass: { mag: 123456n, sign: false },
+ *   radius: { mag: 789n, sign: false },
+ *   scan_status: 4n,
+ *   bonuses: 12345n,
+ *   abundances: 67890n
+ * };
+ * const celestial = Component.fromChain('Celestial', rawCelestial);
+ * // celestial.celestialType, celestial.scanStatus, etc. are now available
+ * // Use directly with entity library methods:
+ * Asteroid.Component.getBonuses(celestial);
+ */
+const fromChain = (componentName, rawData) => {
+  if (!rawData || typeof rawData !== 'object') {
+    throw new Error('rawData must be a non-null object');
+  }
+
+  // Resolve the full ABI key – accept either short name (e.g. 'Celestial') or full path
+  const abiKey = componentName.includes('::')
+    ? componentName
+    : Object.keys(starknetComponents).find((k) => k.endsWith(`::${componentName}`));
+
+  if (!abiKey) {
+    throw new Error(`Unknown component: "${componentName}". Available: ${getComponentNames().join(', ')}`);
+  }
+
+  const schema = starknetComponents[abiKey];
+  const members = schema?.members ?? [];
+
+  const result = {};
+
+  // Map each defined member from snake_case to camelCase
+  for (const member of members) {
+    const snakeKey = member.name;
+    const camelKey = snakeToCamel(snakeKey);
+    if (Object.prototype.hasOwnProperty.call(rawData, snakeKey)) {
+      result[camelKey] = rawData[snakeKey];
+    }
+  }
+
+  // Preserve any extra keys not in the schema (pass-through, still converting names)
+  for (const key of Object.keys(rawData)) {
+    const camelKey = snakeToCamel(key);
+    if (!Object.prototype.hasOwnProperty.call(result, camelKey)) {
+      result[camelKey] = rawData[key];
+    }
+  }
+
+  return result;
+};
+
+/**
+ * Returns the list of available component short names from the ABI.
+ * @returns {string[]}
+ */
+const getComponentNames = () =>
+  Object.keys(starknetComponents).map((k) => k.split('::').pop());
+
+/**
+ * Returns the ABI schema for a component by name.
+ * @param {string} componentName - Short name (e.g. 'Celestial') or full ABI key
+ * @returns {object} ABI schema object with `type` and `members` fields
+ */
+const getSchema = (componentName) => {
+  const abiKey = componentName.includes('::')
+    ? componentName
+    : Object.keys(starknetComponents).find((k) => k.endsWith(`::${componentName}`));
+
+  if (!abiKey) {
+    throw new Error(`Unknown component: "${componentName}". Available: ${getComponentNames().join(', ')}`);
+  }
+
+  return starknetComponents[abiKey];
+};
+
+const Component = {
+  fromChain,
+  getComponentNames,
+  getSchema,
+};
+
+export default Component;

--- a/test/lib/Component.spec.js
+++ b/test/lib/Component.spec.js
@@ -1,0 +1,106 @@
+import { expect } from 'chai';
+import Component from '../../src/lib/Component.js';
+import Asteroid from '../../src/lib/asteroid.js';
+
+describe('Component library', function () {
+  describe('getComponentNames', function () {
+    it('should return a non-empty list of component names', function () {
+      const names = Component.getComponentNames();
+      expect(names).to.be.an('array').that.is.not.empty;
+      expect(names).to.include('Celestial');
+      expect(names).to.include('Crew');
+      expect(names).to.include('Building');
+    });
+  });
+
+  describe('getSchema', function () {
+    it('should return schema for a known component by short name', function () {
+      const schema = Component.getSchema('Celestial');
+      expect(schema).to.be.an('object');
+      expect(schema.members).to.be.an('array').that.is.not.empty;
+      const memberNames = schema.members.map((m) => m.name);
+      expect(memberNames).to.include('celestial_type');
+      expect(memberNames).to.include('bonuses');
+    });
+
+    it('should return schema for a known component by full ABI key', function () {
+      const schema = Component.getSchema('influence::components::celestial::Celestial');
+      expect(schema).to.be.an('object');
+      expect(schema.members).to.be.an('array').that.is.not.empty;
+    });
+
+    it('should throw for an unknown component name', function () {
+      expect(() => Component.getSchema('NonExistent')).to.throw(/Unknown component/);
+    });
+  });
+
+  describe('fromChain', function () {
+    it('should convert snake_case keys to camelCase', function () {
+      const raw = {
+        celestial_type: 3,
+        mass: 100000,
+        radius: 5.5,
+        purchase_order: 1,
+        scan_status: 4,
+        scan_finish_time: 0,
+        bonuses: 12345,
+        abundances: 67890,
+      };
+      const celestial = Component.fromChain('Celestial', raw);
+      expect(celestial).to.have.property('celestialType', 3);
+      expect(celestial).to.have.property('mass', 100000);
+      expect(celestial).to.have.property('radius', 5.5);
+      expect(celestial).to.have.property('scanStatus', 4);
+      expect(celestial).to.have.property('scanFinishTime', 0);
+      expect(celestial).to.have.property('bonuses', 12345);
+      expect(celestial).to.have.property('abundances', 67890);
+      // Original snake_case keys should not be present
+      expect(celestial).to.not.have.property('celestial_type');
+      expect(celestial).to.not.have.property('scan_status');
+    });
+
+    it('should accept full ABI key as component name', function () {
+      const raw = { celestial_type: 7, mass: 1, radius: 10, bonuses: 0, abundances: 0 };
+      const celestial = Component.fromChain('influence::components::celestial::Celestial', raw);
+      expect(celestial).to.have.property('celestialType', 7);
+    });
+
+    it('should pass-through unknown keys (camelCased)', function () {
+      const raw = { celestial_type: 1, extra_field: 'hello' };
+      const celestial = Component.fromChain('Celestial', raw);
+      expect(celestial).to.have.property('celestialType', 1);
+      expect(celestial).to.have.property('extraField', 'hello');
+    });
+
+    it('should throw when rawData is null or missing', function () {
+      expect(() => Component.fromChain('Celestial', null)).to.throw();
+      expect(() => Component.fromChain('Celestial', undefined)).to.throw();
+    });
+
+    it('should throw for unknown component name', function () {
+      expect(() => Component.fromChain('Bogus', { foo: 1 })).to.throw(/Unknown component/);
+    });
+
+    it('should produce a Celestial component usable by Asteroid.Component methods', function () {
+      // Values that produce a deterministic result
+      const rawCelestial = {
+        celestial_type: 7,   // S_TYPE
+        mass: 0,             // not used by getSize/getSpectralType
+        radius: 15,          // km – "Medium" size
+        purchase_order: 0,
+        scan_status: 4,
+        scan_finish_time: 0,
+        bonuses: 0,
+        abundances: 0,
+      };
+      const celestial = Component.fromChain('Celestial', rawCelestial);
+
+      // Asteroid.Component.getSize expects { radius }
+      expect(Asteroid.Component.getSize(celestial)).to.equal('Medium');
+
+      // Asteroid.Component.getSpectralType expects { celestialType }
+      const spectral = Asteroid.Component.getSpectralType(celestial);
+      expect(spectral).to.equal('S');
+    });
+  });
+});


### PR DESCRIPTION
Closes #87

Implements a `Component` library that wraps raw on-chain component data (returned from the `ReadComponent` system) into SDK-compatible objects with camelCase property names.

**Changes:**
- `src/lib/Component.js` — new module with `Component.fromChain(name, rawData)`, `Component.getSchema(name)`, `Component.getComponentNames()`
- `src/index.js` — exports `Component` alongside the other entity libraries
- `test/lib/Component.spec.js` — 10 unit tests (all passing)

**Usage:**
```js
import { Component, Asteroid } from "@influenceth/sdk";
const celestial = Component.fromChain("Celestial", rawOnChainData);
// { celestialType, radius, bonuses, scanStatus, ... }
Asteroid.Component.getSize(celestial); // works with camelCase props
```

/attempt 87